### PR TITLE
Open browser with xdg-open

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -23,7 +23,7 @@ function getBufferContent(nvim, done) {
 function openBrowser(done) {
   var cmd = process.platform === 'darwin' ? 'open' :
     process.platform === 'win32' ? 'start ""' :
-    'google-chrome';
+    'xdg-open';
 
   var outfile = 'http://localhost:35729/markdown';
   debug('... Opening ...', outfile, cmd);


### PR DESCRIPTION
On Linux, it's better to open web pages with [`xdg-open`](https://linux.die.net/man/1/xdg-open) (opens with default programs based on MIME type, and installed by default on many distros) and let that figure out what the default browser is. In some distros, even with Chrome as default, it's `google-chrome-stable` rather than `google-chrome`, and many people probably don't use Chrome either.